### PR TITLE
Fix issues with new chafa

### DIFF
--- a/lua/chafa/health.lua
+++ b/lua/chafa/health.lua
@@ -1,12 +1,12 @@
 local M = {}
 
 M.check = function()
-  vim.health.report_start("chafa.nvim health check")
+  vim.health.start("chafa.nvim health check")
   if vim.fn.executable("chafa") == 1 then
-    vim.health.report_ok("no issues found")
+    vim.health.ok("no issues found")
   else
-    vim.health.report_error("chafa executable not found")
-    vim.health.report_info("Follow installations instructions at https://hpjansson.org/chafa/download/")
+    vim.health.error("chafa executable not found")
+    vim.health.info("Follow installations instructions at https://hpjansson.org/chafa/download/")
   end
 end
 

--- a/lua/chafa/init.lua
+++ b/lua/chafa/init.lua
@@ -11,13 +11,12 @@ local global_opts = nil
 
 ---@diagnostic disable-next-line: unused-local
 local get_image_data_sync = function(buf_path, width, height, opts, callback)
-  local command = { "chafa", buf_path, "--size", width .. "x" .. height, "--format", "symbols" }
+  local command = { "chafa", buf_path, "--size", width .. "x" .. height, "--format", "symbols", "--polite", "on" }
 
   vim.fn.jobstart(command, {
     stdout_buffered = true,
     on_stdout = function(_, data)
       if data then
-        table.remove(data)
         callback(data)
       end
     end,

--- a/lua/chafa/init.lua
+++ b/lua/chafa/init.lua
@@ -11,7 +11,7 @@ local global_opts = nil
 
 ---@diagnostic disable-next-line: unused-local
 local get_image_data_sync = function(buf_path, width, height, opts, callback)
-  local command = { "chafa", buf_path, "--size", width .. "x" .. height }
+  local command = { "chafa", buf_path, "--size", width .. "x" .. height, "--format", "symbols" }
 
   vim.fn.jobstart(command, {
     stdout_buffered = true,


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`92b284a`](https://github.com/princejoogie/chafa.nvim/pull/13/commits/92b284a37584f787acd151e2d39255eacb033c34) fix: add chafa arguments '--format symbols'

Otherwise chafa chooses a protocol based on the terminal.


### [`46a42fb`](https://github.com/princejoogie/chafa.nvim/pull/13/commits/46a42fba674f746321e0bc2a23ca9805dee8a60b) fix: use chafa arguments '--polite on' to suppress escape sequences

Chafa printed '\033[?25h' to hide the cursor.

Adding a table.remove(data, 1) works too under *nix but '--polite on'
should cater for Windows at the same time.

[1] https://github.com/hpjansson/chafa/blob/aa8a3d928c9b476f548c9c79cce03cc80f437239/tools/chafa/chafa.c#L1656-L1659


### [`3c8f412`](https://github.com/princejoogie/chafa.nvim/pull/13/commits/3c8f412cf6fdfcb002f64813a75907f22b57ac36) fix: migrate to new vim.health APIs



<!-- === GH HISTORY FENCE === -->

Fixes #8

Fixes #10
